### PR TITLE
Fix deploy reference

### DIFF
--- a/.github/workflows/firebase-hosting-deploy.yml
+++ b/.github/workflows/firebase-hosting-deploy.yml
@@ -26,15 +26,15 @@ jobs:
         run: cp main.css public/
         
       - name: Copy assets folder to public folder
-        run: cp -r assets/* public/
+        run: cp -r assets public/
 
       - name: Copy pages folder to public folder
-        run: cp -r pages/* public/
+        run: cp -r pages public/
 
       - name: Copy styles folder to public folder
-        run: cp -r styles/* public/
+        run: cp -r styles public/
 
       - name: Authenticate and Deploy with Firebase
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }} # Define token a env variable
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: firebase deploy --only hosting --project igrejaviverbemibv --token $FIREBASE_TOKEN


### PR DESCRIPTION
## What are you doing? Featute, Fix bug, enhancement...

o comando `cp -r assets/* public/` copia apenas os arquivos dentro de `assets/`, e não a pasta `assets `em si. Isso causa os problemas com caminhos quebrados no deploy final.

correto é assim:
`  run: cp -r assets public/`
  
## Evidence of your change

## Checklist 💡 
- Add a proper label
- Add a description to the PR